### PR TITLE
Split five columns

### DIFF
--- a/lib/xlsx/sheet.xml
+++ b/lib/xlsx/sheet.xml
@@ -16,9 +16,7 @@
   <sheetViews>
     <sheetView workbookViewId="0">
       <!--xSplit attribute represents the no of cols freezed.The value will always be 1 for this case.-->
-      <pane xSplit="1" topLeftCell="B1" activePane="topRight" state="frozen"/>
-      <!-- worksheet view selection to the selected pane-->
-      <selection pane="topRight" activeCell="F18" sqref="F18"/>
+      <pane xSplit="5" topLeftCell="F1" activePane="topRight" state="frozen"/>
     </sheetView>
   </sheetViews>
   <sheetFormatPr defaultRowHeight="15" x14ac:dyDescent="0.25"/>


### PR DESCRIPTION
We need to show the budget fixed to the left. Since the budget is comprised of four columns (unit, quantity, unit cost, and total cost) we need to fix five columns to the left. 

I also removed the selection which was added in https://github.com/BuildingConnected/exceljs/commit/eea2df7dbf8744de462c1f828a657a2ce591ffd5 but seemingly just selects a cell for no reason. @cannoneyed hoping you can confirm that it's safe to remove that line.

Test Plan:
### Setting up `exceljs` as an NPM local module (DO THIS FIRST)
1. Clone `exceljs` as a sibling to your `BC` repo
2. Check out this `five-fixed-columns` branch of the `exceljs` repo
3. Edit your `BC` repo's `package.json`, changing the version string of `"@buildingconnected/bid-form/util"` from `"git://github.com/BuildingConnected/exceljs.git"` to `"file:../exceljs"`
4. From within your `client` repo run `rm -rf node_modules/\exceljs && npm i exceljs --no-shrinkwrap`
5. Restart your `npm start` `BC` process
### Actually test it works
1. Go to a bid package's budget and proposal tab (checkout `budget-1` in the `client` repo)
2. Click "download excel" 
3. Ensure the excel has five columns fixed to the left (I'll merge this after I have the target bid actually rendering in the 2-5 columns)
### Tear down
1. Revert the change you made to `package.json`
2. Run `rm -rf node_modules/\exceljs && npm i exceljs` again
