### PR TITLE
Add configurable split option and include styles on empty cells

### DIFF
--- a/lib/row.js
+++ b/lib/row.js
@@ -237,17 +237,15 @@ Row.prototype = {
     var min = 0;
     var max = 0;
     _.each(this._cells, function (cell) {
-      if (cell.type != Enums.ValueType.Null) {
-        var cellModel = cell.model;
-        if (cellModel) {
-          if (!min || (min > cell.col)) {
-            min = cell.col;
-          }
-          if (max < cell.col) {
-            max = cell.col;
-          }
-          cells.push(cellModel);
+      var cellModel = cell.model;
+      if (cellModel) {
+        if (!min || (min > cell.col)) {
+          min = cell.col;
         }
+        if (max < cell.col) {
+          max = cell.col;
+        }
+        cells.push(cellModel);
       }
     });
 
@@ -273,7 +271,6 @@ Row.prototype = {
     _.each(value.cells, function (cellModel) {
       //console.log(JSON.stringify(colCache.decodeAddress(cellModel.address)) + " ==> " + JSON.stringify(cellModel));
       switch (cellModel.type) {
-        case Cell.Types.Null:
         case Cell.Types.Merge:
           // special case - don't add these types
           break;

--- a/lib/worksheet.js
+++ b/lib/worksheet.js
@@ -46,6 +46,9 @@ var Worksheet = module.exports = function(options) {
 
   // and a name
   this.name = options.name || "Sheet" + this.id;
+  
+  // and, optionally, split data
+  this.split = options.split;
 
   // rows allows access organised by row. Sparse array of arrays indexed by row-1, col
   // Note: _rows is zero based. Must subtract 1 to go from cell.row to index
@@ -291,7 +294,8 @@ Worksheet.prototype = {
     var model = {
       id: this.id,
       name: utils.xmlEncode(this.name),
-      tabColor: this.tabColor
+      tabColor: this.tabColor,
+      split: this.split,
     };
 
     // =================================================

--- a/lib/xlsx/sheet.xml
+++ b/lib/xlsx/sheet.xml
@@ -16,7 +16,7 @@
   <sheetViews>
     <% if (split) { %>
       <sheetView workbookViewId="0">
-        <!--xSplit attribute represents the no of cols freezed.The value will always be 1 for this case.-->
+        <!--xSplit attribute represents the no of cols freezed.-->
         <pane
           xSplit="<%=split.split%>"
           topLeftCell="<%=split.topLeftCell%>"

--- a/lib/xlsx/sheet.xml
+++ b/lib/xlsx/sheet.xml
@@ -14,12 +14,18 @@
 
   <dimension ref="<%=dimensions%>"/>
   <sheetViews>
-    <sheetView workbookViewId="0">
-      <!--xSplit attribute represents the no of cols freezed.The value will always be 1 for this case.-->
-      <pane xSplit="1" topLeftCell="B1" activePane="topRight" state="frozen"/>
-      <!-- worksheet view selection to the selected pane-->
-      <selection pane="topRight" activeCell="F18" sqref="F18"/>
-    </sheetView>
+    <% if (split) { %>
+      <sheetView workbookViewId="0">
+        <!--xSplit attribute represents the no of cols freezed.The value will always be 1 for this case.-->
+        <pane
+          xSplit="<%=split.split%>"
+          topLeftCell="<%=split.topLeftCell%>"
+          activePane="<%=split.activePane%>"
+          state="<%=split.state%>"/>
+      </sheetView>
+    <% } else { %>
+      <sheetView workbookViewId="0" />
+    <% } %>
   </sheetViews>
   <sheetFormatPr defaultRowHeight="15" x14ac:dyDescent="0.25"/>
   

--- a/lib/xlsx/sheet.xml
+++ b/lib/xlsx/sheet.xml
@@ -46,7 +46,6 @@
       <row r="<%=row.number%>"
            <% if(row.height) {%> ht="<%=row.height%>" customHeight="1"<% } %>
            <% if(row.hidden) {%> hidden="1"<% } %>
-           spans="<%=row.min%>:<%=row.max%>"
            <% if (row.styleId) { %> s="<%=row.styleId%>" customFormat="1" <% } %>
            x14ac:dyDescent="0.25">
       <% _.each(row.cells, function(cell){ %>

--- a/lib/xlsx/xlsx.js
+++ b/lib/xlsx/xlsx.js
@@ -1129,6 +1129,7 @@ XLSX.prototype = {
               }
               break;
             case Enums.ValueType.Merge:
+            default:
               cell.xml = buildC(cell, undefined, true);
               break;
           }

--- a/lib/xlsx/xlsx.js
+++ b/lib/xlsx/xlsx.js
@@ -1142,6 +1142,10 @@ XLSX.prototype = {
         worksheet.hyperlinks = false;
       }
 
+      if (worksheet.split && worksheet.split.split) {
+        worksheet.split.topLeftCell = colCache.n2l(worksheet.split.split + 1) + '1'
+      }
+
       promises.push(utils.fetchTemplate(require.resolve("./sheet.xml"))
         .then(function (template) {
           return template(worksheet);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "exceljs",
-    "version": "0.2.4",
+    "version": "0.3.0",
     "description": "Excel Workbook Manager - Read and Write xlsx and csv Files.",
     "private": false,
     "license": "MIT",


### PR DESCRIPTION
## Description

There were two things in `exceljs` that I needed to fix in order to make https://github.com/BuildingConnected/BC/pull/2099 work:
- The original https://github.com/guyonroche/exceljs module has no support for setting up fixed panes. We had hacked this to always set the first column to fixed, but for the latest Excel work we need to be able to set 3 columns as fixed, and I'm sure we'll have other use cases in the future. So I added the ability to configure how a pane is split.
- The original exceljs module has a [nasty issue](https://github.com/guyonroche/exceljs/issues/82) where styles applied to cells without values won't get applied. That simply will not do, since we need certain cells to be styled (have borders, backgrounds, etc) but not have a value so that Excel will let their neighboring cells' content bleed into them. So I made it much more lax about which cells get rendered.
## Test Plan

Follow the test plan on https://github.com/BuildingConnected/BC/pull/2099
